### PR TITLE
Fixes to app redirects, upstream errors & proper headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/src/constants.py
+++ b/src/constants.py
@@ -24,6 +24,11 @@ http <
 
         location / <
             proxy_pass http://main;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
         >
     >
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -24,6 +24,7 @@ http <
 
         location / <
             proxy_pass http://main;
+            proxy_next_upstream error timeout invalid_header http_502 http_503 http_504;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/constants.py
+++ b/src/constants.py
@@ -16,6 +16,9 @@ http <
 {upstream_server_localhosts}
     >
 
+    absolute_redirect off;
+    port_in_redirect off;
+
     server <
         listen {port};
 


### PR DESCRIPTION
This PR addresses a few things:
1. It resolves #8 which was causing any 301 redirects from the upstream apps to not work properly
2. Properly handles errors by moving to the next upstream app using `proxy_next_upstream`. This means that if a Heroku app has any issues with responding, it will move to the next app
3. Sets commonly used headers that are needed as part of load balancing